### PR TITLE
Support short names for named VMs (not "default")

### DIFF
--- a/vboxss.go
+++ b/vboxss.go
@@ -116,6 +116,7 @@ func retrieve_vms() (vms []vm, err error) {
 
 	re_line, _ := regexp.Compile(`"([^"]+)"\s+{([^}]+)}`)
 	re_vmname, _ := regexp.Compile(`^(.+)_default_[0-9_]+`)
+	re_vmname_long, _ := regexp.Compile(`^([^_]+_[^_]+)_[0-9_]+`)
 	for {
 		line, err := out.ReadString('\n')
 		if err == io.EOF {
@@ -133,6 +134,11 @@ func retrieve_vms() (vms []vm, err error) {
 			match := re_vmname.FindStringSubmatch(vmname)
 			if match != nil {
 				short_vmname = match[1]
+			} else {
+				match = re_vmname_long.FindStringSubmatch(vmname)
+				if match != nil {
+					short_vmname = match[1]
+				}
 			}
 
 			vms = append(vms, vm{vmname, short_vmname, uuid})


### PR DESCRIPTION
Hi, I wrote codes for #1 .
And it worked. Here is my console's output:

``` sh
## Vagrantfile is located in ~/Vagrant/bento-centos65/ directory
$ vboxss list
bento-centos65_chef bento-centos65_chef_1429095396402_60198
bento-centos65_node bento-centos65_node_1429095435994_29166
$ vboxss take bento-centos65_chef foo
Take snapshot of bento-centos65_chef_1429095396402_60198 as 'foo'... done!
$ vboxss list bento-centos65_chef
List of the snapshots of bento-centos65_chef_1429095396402_60198
foo                                     b4448a10-c46a-4c28-9588-4f69feed0d9c
```

Single VM named "default" also works with this.

``` sh
## A single VM defined in ~/Vagrant/centos65/Vagrantfile
$ vboxss list
centos65           centos65_default_1420958999672_33650
bento-centos65_chef bento-centos65_chef_1429095396402_60198
bento-centos65_node bento-centos65_node_1429095435994_29166
```

I will appreciate if you like this change.
Thanks,
